### PR TITLE
Python3 support

### DIFF
--- a/nose_allure/__init__.py
+++ b/nose_allure/__init__.py
@@ -147,7 +147,15 @@ class Allure(Plugin):
 
     @staticmethod
     def _parse_tb(trace):
-        message = ''.join(
-            traceback.format_exception_only(trace[0], trace[1])).strip()
-        trace = ''.join(traceback.format_exception(*trace)).strip()
+        try:
+            message = ''.join(
+                traceback.format_exception_only(trace[0], trace[1])).strip()
+            trace = ''.join(traceback.format_exception(*trace)).strip()
+        except AttributeError:
+            # in python 3 AttributeError: 'str' object has no attribute '__cause__' is thrown here
+            # traceback.format_exception() now expects the second argument to be an exception instance
+            _trace = (trace[0], trace[0](trace[1])) + trace[2:]
+            message = ''.join(traceback.format_exception_only(_trace[0], _trace[1])).strip()
+            trace = ''.join(traceback.format_exception(*_trace)).strip()
+
         return message, trace

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
     name='nose-allure-plugin',
-    version='1.0.5',
+    version='1.0.6',
     description='Nose plugin for allure framework',
     long_description=open('README.rst').read(),
     author='Sergey Chipiga',


### PR DESCRIPTION
in python 3 "AttributeError: 'str' object has no attribute '__cause__'" is thrown in _parse_tb. "traceback.format_exception" in python3 requires 2nd arg to be BaseException instance. This implementation should allow for this to work both in python2 and in python3.
I'm fixing it here, since I can't find nose allure plugin for nose2/allure2, and thus still using nose.